### PR TITLE
Loop background music on all pages

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -6,6 +6,21 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+  <!-- Hidden, looping background music -->
+  <audio id="bgm" loop preload="auto" style="display:none">
+    <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
+    Your browser doesn’t support HTML5 audio.
+  </audio>
+  <script>
+    document.addEventListener('click', function startBGM() {
+      const bgm = document.getElementById('bgm');
+      if (bgm && bgm.paused) {
+        bgm.volume = 0.5;
+        bgm.play().catch(() => { });
+      }
+      document.removeEventListener('click', startBGM);
+    }, { once: true });
+  </script>
   <div id="loading-overlay">
     <div class="spinner"></div>
     <p>Loading… please wait.</p>

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -6,6 +6,21 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
+  <!-- Hidden, looping background music -->
+  <audio id="bgm" loop preload="auto" style="display:none">
+    <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
+    Your browser doesn’t support HTML5 audio.
+  </audio>
+  <script>
+    document.addEventListener('click', function startBGM() {
+      const bgm = document.getElementById('bgm');
+      if (bgm && bgm.paused) {
+        bgm.volume = 0.5;
+        bgm.play().catch(() => { });
+      }
+      document.removeEventListener('click', startBGM);
+    }, { once: true });
+  </script>
   <div class="container">
     <h1>Battle: {{ player.name }} vs {{ enemy.name }}</h1>
     <div class="stats">

--- a/Flask/Templates/inventory.html
+++ b/Flask/Templates/inventory.html
@@ -27,6 +27,21 @@
   </style>
 </head>
 <body>
+  <!-- Hidden, looping background music -->
+  <audio id="bgm" loop preload="auto" style="display:none">
+    <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
+    Your browser doesn’t support HTML5 audio.
+  </audio>
+  <script>
+    document.addEventListener('click', function startBGM() {
+      const bgm = document.getElementById('bgm');
+      if (bgm && bgm.paused) {
+        bgm.volume = 0.5;
+        bgm.play().catch(() => { });
+      }
+      document.removeEventListener('click', startBGM);
+    }, { once: true });
+  </script>
   <div class="container">
     <h1>Inventory</h1>
 

--- a/Flask/Templates/loading.html
+++ b/Flask/Templates/loading.html
@@ -34,6 +34,21 @@
   </style>
 </head>
 <body>
+  <!-- Hidden, looping background music -->
+  <audio id="bgm" loop preload="auto" style="display:none">
+    <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
+    Your browser doesn’t support HTML5 audio.
+  </audio>
+  <script>
+    document.addEventListener('click', function startBGM() {
+      const bgm = document.getElementById('bgm');
+      if (bgm && bgm.paused) {
+        bgm.volume = 0.5;
+        bgm.play().catch(() => { });
+      }
+      document.removeEventListener('click', startBGM);
+    }, { once: true });
+  </script>
   <div class="loading-container">
     <div class="spinner"></div>
     <p>Thinking… one moment please.</p>

--- a/Flask/Templates/save_as.html
+++ b/Flask/Templates/save_as.html
@@ -6,6 +6,21 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
   </head>
   <body>
+    <!-- Hidden, looping background music -->
+    <audio id="bgm" loop preload="auto" style="display:none">
+      <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
+      Your browser doesn’t support HTML5 audio.
+    </audio>
+    <script>
+      document.addEventListener('click', function startBGM() {
+        const bgm = document.getElementById('bgm');
+        if (bgm && bgm.paused) {
+          bgm.volume = 0.5;
+          bgm.play().catch(() => { });
+        }
+        document.removeEventListener('click', startBGM);
+      }, { once: true });
+    </script>
     <div class="container">
       <h1>Save Game As…</h1>
       <form method="post">


### PR DESCRIPTION
## Summary
- ensure the background music element exists on every template
- start the music on first click for all pages

## Testing
- `python -m compileall -q Game_Modules Flask`

------
https://chatgpt.com/codex/tasks/task_e_68746b784bdc83208a1e90e17b260499