### PR TITLE
Add persistent background music with toggle

### DIFF
--- a/Flask/Templates/base.html
+++ b/Flask/Templates/base.html
@@ -30,7 +30,7 @@
 </head>
 <body>
   <!-- 1) Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" style="display:none">
+  <audio id="bgm" loop preload="auto" autoplay style="display:none">
     <source
       src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}"
       type="audio/mpeg">
@@ -38,18 +38,8 @@
     Your browser doesn’t support HTML5 audio.
   </audio>
 
-  <!-- 2) Kick it off on first user click -->
-  <script>
-    document.addEventListener('click', function startBGM() {
-      const bgm = document.getElementById('bgm');
-      if (bgm && bgm.paused) {
-        bgm.volume = 0.5;  // adjust 0.0–1.0
-        bgm.play().catch(()=>{ /* ignore if still blocked */ });
-      }
-      // only once
-      document.removeEventListener('click', startBGM);
-    }, { once: true });
-  </script>
+  <!-- 2) Background music helper -->
+  <script src="{{ url_for('static', filename='bgm.js') }}"></script>
 
   <!-- overlay sits on top of all content -->
   <div id="loading-overlay">

--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -7,20 +7,11 @@
 </head>
 <body>
   <!-- Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" style="display:none">
+  <audio id="bgm" loop preload="auto" autoplay style="display:none">
     <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
     Your browser doesn’t support HTML5 audio.
   </audio>
-  <script>
-    document.addEventListener('click', function startBGM() {
-      const bgm = document.getElementById('bgm');
-      if (bgm && bgm.paused) {
-        bgm.volume = 0.5;
-        bgm.play().catch(() => { });
-      }
-      document.removeEventListener('click', startBGM);
-    }, { once: true });
-  </script>
+  <script src="{{ url_for('static', filename='bgm.js') }}"></script>
   <div id="loading-overlay">
     <div class="spinner"></div>
     <p>Loading… please wait.</p>

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -7,20 +7,11 @@
 </head>
 <body>
   <!-- Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" style="display:none">
+  <audio id="bgm" loop preload="auto" autoplay style="display:none">
     <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
     Your browser doesn’t support HTML5 audio.
   </audio>
-  <script>
-    document.addEventListener('click', function startBGM() {
-      const bgm = document.getElementById('bgm');
-      if (bgm && bgm.paused) {
-        bgm.volume = 0.5;
-        bgm.play().catch(() => { });
-      }
-      document.removeEventListener('click', startBGM);
-    }, { once: true });
-  </script>
+  <script src="{{ url_for('static', filename='bgm.js') }}"></script>
   <div class="container">
     <h1>Battle: {{ player.name }} vs {{ enemy.name }}</h1>
     <div class="stats">

--- a/Flask/Templates/inventory.html
+++ b/Flask/Templates/inventory.html
@@ -28,20 +28,11 @@
 </head>
 <body>
   <!-- Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" style="display:none">
+  <audio id="bgm" loop preload="auto" autoplay style="display:none">
     <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
     Your browser doesn’t support HTML5 audio.
   </audio>
-  <script>
-    document.addEventListener('click', function startBGM() {
-      const bgm = document.getElementById('bgm');
-      if (bgm && bgm.paused) {
-        bgm.volume = 0.5;
-        bgm.play().catch(() => { });
-      }
-      document.removeEventListener('click', startBGM);
-    }, { once: true });
-  </script>
+  <script src="{{ url_for('static', filename='bgm.js') }}"></script>
   <div class="container">
     <h1>Inventory</h1>
 

--- a/Flask/Templates/loading.html
+++ b/Flask/Templates/loading.html
@@ -35,20 +35,11 @@
 </head>
 <body>
   <!-- Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" style="display:none">
+  <audio id="bgm" loop preload="auto" autoplay style="display:none">
     <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
     Your browser doesn’t support HTML5 audio.
   </audio>
-  <script>
-    document.addEventListener('click', function startBGM() {
-      const bgm = document.getElementById('bgm');
-      if (bgm && bgm.paused) {
-        bgm.volume = 0.5;
-        bgm.play().catch(() => { });
-      }
-      document.removeEventListener('click', startBGM);
-    }, { once: true });
-  </script>
+  <script src="{{ url_for('static', filename='bgm.js') }}"></script>
   <div class="loading-container">
     <div class="spinner"></div>
     <p>Thinking… one moment please.</p>

--- a/Flask/Templates/save_as.html
+++ b/Flask/Templates/save_as.html
@@ -7,20 +7,11 @@
   </head>
   <body>
     <!-- Hidden, looping background music -->
-    <audio id="bgm" loop preload="auto" style="display:none">
+    <audio id="bgm" loop preload="auto" autoplay style="display:none">
       <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
       Your browser doesn’t support HTML5 audio.
     </audio>
-    <script>
-      document.addEventListener('click', function startBGM() {
-        const bgm = document.getElementById('bgm');
-        if (bgm && bgm.paused) {
-          bgm.volume = 0.5;
-          bgm.play().catch(() => { });
-        }
-        document.removeEventListener('click', startBGM);
-      }, { once: true });
-    </script>
+    <script src="{{ url_for('static', filename='bgm.js') }}"></script>
     <div class="container">
       <h1>Save Game As…</h1>
       <form method="post">

--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -15,10 +15,22 @@
         <option value="Hard"   {% if current=='Hard'   %}selected{% endif %}>Hard</option>
       </select>
     </label>
+    <label style="margin-left:1rem;">
+      <input type="checkbox" id="music-toggle"> Music
+    </label>
     <div class="button-row">
       <button type="submit" class="button">Save Settings</button>
       <a class="button" href="{{ url_for('menu') }}">← Back</a>
     </div>
   </form>
 </div>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('music-toggle');
+    toggle.checked = localStorage.getItem('bgmEnabled') !== 'false';
+    toggle.addEventListener('change', () => {
+      window.setBgmEnabled(toggle.checked);
+    });
+  });
+</script>
 {% endblock %}

--- a/Flask/static/bgm.js
+++ b/Flask/static/bgm.js
@@ -1,0 +1,42 @@
+(() => {
+  const storage = window.localStorage;
+  const ENABLED = 'bgmEnabled';
+  const TIME = 'bgmTime';
+
+  function init() {
+    const audio = document.getElementById('bgm');
+    if (!audio) return;
+
+    if (storage.getItem(ENABLED) === null) {
+      storage.setItem(ENABLED, 'true');
+    }
+    const enabled = storage.getItem(ENABLED) === 'true';
+
+    const start = parseFloat(storage.getItem(TIME)) || 0;
+    if (!isNaN(start)) {
+      audio.currentTime = start;
+    }
+    audio.volume = 0.5;
+
+    if (enabled) {
+      audio.play().catch(() => {});
+    }
+
+    window.addEventListener('beforeunload', () => {
+      storage.setItem(TIME, audio.currentTime);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  window.setBgmEnabled = function(flag) {
+    storage.setItem(ENABLED, flag ? 'true' : 'false');
+    const audio = document.getElementById('bgm');
+    if (!audio) return;
+    if (flag) {
+      audio.play().catch(() => {});
+    } else {
+      audio.pause();
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- start BGM automatically and persist playback time across pages
- add bgm.js helper script
- hook bgm.js into all templates
- add music toggle in settings menu

## Testing
- `pytest Flask -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68746d769f4083209c77665a4080a24e