### PR TITLE
Fix BGM playback continuity

### DIFF
--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -28,6 +28,7 @@
   document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('music-toggle');
     toggle.checked = localStorage.getItem('bgmEnabled') !== 'false';
+    window.setBgmEnabled(toggle.checked);
     toggle.addEventListener('change', () => {
       window.setBgmEnabled(toggle.checked);
     });

--- a/Flask/static/bgm.js
+++ b/Flask/static/bgm.js
@@ -13,14 +13,26 @@
     const enabled = storage.getItem(ENABLED) === 'true';
 
     const start = parseFloat(storage.getItem(TIME)) || 0;
-    if (!isNaN(start)) {
-      audio.currentTime = start;
-    }
     audio.volume = 0.5;
 
-    if (enabled) {
-      audio.play().catch(() => {});
+    function resume() {
+      if (!isNaN(start)) {
+        audio.currentTime = start;
+      }
+      if (enabled) {
+        audio.play().catch(() => {});
+      }
     }
+
+    if (audio.readyState >= 1) {
+      resume();
+    } else {
+      audio.addEventListener('loadedmetadata', resume, { once: true });
+    }
+
+    audio.addEventListener('timeupdate', () => {
+      storage.setItem(TIME, audio.currentTime);
+    });
 
     window.addEventListener('beforeunload', () => {
       storage.setItem(TIME, audio.currentTime);
@@ -34,6 +46,10 @@
     const audio = document.getElementById('bgm');
     if (!audio) return;
     if (flag) {
+      const start = parseFloat(storage.getItem(TIME)) || 0;
+      if (!isNaN(start)) {
+        audio.currentTime = start;
+      }
       audio.play().catch(() => {});
     } else {
       audio.pause();


### PR DESCRIPTION
## Summary
- store and restore audio position when navigating pages
- update settings toggle to apply current music state on load

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6874702c152483208c27d9f0623f4514