### PR TITLE
Fix music toggle not persisting

### DIFF
--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -16,7 +16,7 @@
       </select>
     </label>
     <label style="margin-left:1rem;">
-      <input type="checkbox" id="music-toggle"> Music
+      <input type="checkbox" id="music-toggle" name="music" {% if music_enabled %}checked{% endif %}> Music
     </label>
     <div class="button-row">
       <button type="submit" class="button">Save Settings</button>
@@ -27,7 +27,12 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const toggle = document.getElementById('music-toggle');
-    toggle.checked = localStorage.getItem('bgmEnabled') !== 'false';
+    const stored = localStorage.getItem('bgmEnabled');
+    if (stored === null) {
+      toggle.checked = {{ 'true' if music_enabled else 'false' }};
+    } else {
+      toggle.checked = stored !== 'false';
+    }
     window.setBgmEnabled(toggle.checked);
     toggle.addEventListener('change', () => {
       window.setBgmEnabled(toggle.checked);

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -166,16 +166,20 @@ def load_save():
 
 @app.route('/settings', methods=['GET', 'POST'])
 def settings():
-    # Simple stub: store e.g. "difficulty" in session
+    # Persist difficulty and music toggle in session
     if request.method == 'POST':
         diff = request.form.get('difficulty')
+        music = request.form.get('music') == 'on'
         session['settings'] = session.get('settings', {})
         session['settings']['difficulty'] = diff
+        session['settings']['music'] = music
         flash(f"Difficulty set to {diff}", "success")
         return redirect(url_for('menu'))
-    # On GET, show the form
+
+    # On GET, show the form with current settings
     current = session.get('settings', {}).get('difficulty', 'Normal')
-    return render_template('settings.html', current=current)
+    music_enabled = session.get('settings', {}).get('music', True)
+    return render_template('settings.html', current=current, music_enabled=music_enabled)
 
 # ----- EXPLORE -----
 @app.route('/explore', methods=['GET','POST'])


### PR DESCRIPTION
## Summary
- remember music checkbox state in server session
- initialize checkbox from stored preference

## Testing
- `pytest -q` *(fails: No module named 'parameterized')*

------
https://chatgpt.com/codex/tasks/task_e_6874723ccbd48320ae0a99fc728271ea