### PR TITLE
Fix difficulty-based HP

### DIFF
--- a/Flask/Templates/menu.html
+++ b/Flask/Templates/menu.html
@@ -21,6 +21,14 @@
       Enter your name:
       <input type="text" name="name" required style="font-family:inherit;">
     </label>
+    <label style="margin-left:1rem;">
+      Difficulty:
+      <select name="difficulty">
+        <option value="Easy"   {% if current=='Easy'   %}selected{% endif %}>Easy</option>
+        <option value="Normal" {% if current=='Normal' %}selected{% endif %}>Normal</option>
+        <option value="Hard"   {% if current=='Hard'   %}selected{% endif %}>Hard</option>
+      </select>
+    </label>
     <button type="submit" class="button">Begin Adventure</button>
   </form>
 

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -32,15 +32,17 @@ ROOM_NAMES = {rid: get_room_name(rid) for rid in dungeon_map.rooms.keys()}
 # ----- MAIN MENU -----
 @app.route('/')
 def menu():
-    return render_template('menu.html')
+    current = session.get('settings', {}).get('difficulty', 'Normal')
+    return render_template('menu.html', current=current)
 
 @app.route('/start', methods=['POST'])
 def start_game():
     """Begin a new game using the selected difficulty settings."""
-    # Preserve settings then clear any old session
-    settings = session.get('settings', {})
-    diff    = settings.get('difficulty', 'Normal')
-    music   = settings.get('music', True)
+    # Difficulty may come from a form field or previous settings
+    form_diff = request.form.get('difficulty')
+    settings  = session.get('settings', {})
+    diff      = form_diff or settings.get('difficulty', 'Normal')
+    music     = settings.get('music', True)
     session.clear()
     session['settings'] = {'difficulty': diff, 'music': music}
 

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -40,6 +40,18 @@ def test_start_game_difficulty(client, diff, expected):
         assert sess['hp'] == expected
         assert sess['difficulty'] == diff
 
+@pytest.mark.parametrize('diff,expected', [
+    ('Easy', 100),
+    ('Normal', 50),
+    ('Hard', 10),
+])
+def test_start_game_difficulty_form(client, diff, expected):
+    resp = client.post('/start', data={'name': 'Hero', 'difficulty': diff})
+    assert resp.status_code == 302
+    with client.session_transaction() as sess:
+        assert sess['hp'] == expected
+        assert sess['difficulty'] == diff
+
 def test_rng_route(client):
     resp = client.get('/rng?min=1&max=10')
     assert resp.data.strip() == b'5'


### PR DESCRIPTION
## Summary
- allow selecting difficulty from the main menu
- use difficulty form value when starting a game
- test difficulty selection via POST data

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_6876fe5a20b88320b3fdd1b830354720