### PR TITLE
Enhance settings menu with new options

### DIFF
--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -18,6 +18,36 @@
     <label style="margin-left:1rem;">
       <input type="checkbox" id="music-toggle" name="music" {% if music_enabled %}checked{% endif %}> Music
     </label>
+    <br>
+    <label>
+      LLM Return Length:
+      <input type="number" name="llm_return_length" min="15" max="100" value="{{ llm_length }}">
+    </label>
+    <label style="margin-left:1rem;">
+      <input type="checkbox" name="voice" {% if voice_enabled %}checked{% endif %}> Voice
+    </label>
+    <br>
+    <label>
+      Map Size:
+      <select name="map_size">
+        <option value="Small"  {% if map_size=='Small'  %}selected{% endif %}>Small</option>
+        <option value="Medium" {% if map_size=='Medium' %}selected{% endif %}>Medium</option>
+        <option value="Large"  {% if map_size=='Large'  %}selected{% endif %}>Large</option>
+      </select>
+    </label>
+    <label style="margin-left:1rem;">
+      <input type="checkbox" name="randomize_map" {% if randomize_map %}checked{% endif %}> Randomize Map
+    </label>
+    <br>
+    <label>
+      Display Theme:
+      <select name="display_theme">
+        <option value="Standard" {% if display_theme=='Standard' %}selected{% endif %}>Standard</option>
+        <option value="Light"    {% if display_theme=='Light'    %}selected{% endif %}>Light</option>
+        <option value="Burnt"    {% if display_theme=='Burnt'    %}selected{% endif %}>Burnt</option>
+        <option value="Retro"    {% if display_theme=='Retro'    %}selected{% endif %}>Retro</option>
+      </select>
+    </label>
     <div class="button-row">
       <button type="submit" class="button">Save Settings</button>
       <a class="button" href="{{ url_for('menu') }}">← Back</a>

--- a/Game_Modules/game_utils.py
+++ b/Game_Modules/game_utils.py
@@ -88,7 +88,8 @@ def move_player(session, tgt_room, spawn_chance=0.6):
         # lazy-generate description and write it back to the master list
         if not e.get('llm_description'):
             ctx = {'name': e['name'], 'level': e.get('level',1)}
-            desc = llm_client.generate_description('enemy', ctx)
+            length = session.get('settings', {}).get('llm_return_length', 50)
+            desc = llm_client.generate_description('enemy', ctx, length)
             e['llm_description'] = desc
             # persist into RAW_ENEMIES so your save will include it
             for master in RAW_ENEMIES:
@@ -137,7 +138,8 @@ def search_room(session, search_chance=0.5):
                 'stats': {k:v for k,v in found.items()
                           if k not in ('name','type','drop_rate')}
             }
-            found['llm_description'] = llm_client.generate_description('gear', ctx)
+            length = session.get('settings', {}).get('llm_return_length', 50)
+            found['llm_description'] = llm_client.generate_description('gear', ctx, length)
 
         # Append to the player's inventory
         inv = session.setdefault('inventory', [])


### PR DESCRIPTION
## Summary
- extend `start_game` to preserve new settings
- add form fields for LLM length, voice, map and theme options
- store settings for difficulty, music and new fields
- use custom LLM length when generating descriptions

## Testing
- `python tests/run_all_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_6879a46088c08320b073cffa0de35dc9