### PR TITLE
Fix music autoplay when disabled

### DIFF
--- a/Flask/Templates/base.html
+++ b/Flask/Templates/base.html
@@ -129,7 +129,7 @@
   <div class="bg-particles"></div>
 
   <!-- Background music -->
-  <audio id="bgm" loop preload="auto" autoplay style="display:none">
+  <audio id="bgm" loop preload="auto" style="display:none">
     <source
       src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}"
       type="audio/mpeg">

--- a/Flask/Templates/loading.html
+++ b/Flask/Templates/loading.html
@@ -35,7 +35,7 @@
 </head>
 <body>
   <!-- Hidden, looping background music -->
-  <audio id="bgm" loop preload="auto" autoplay style="display:none">
+  <audio id="bgm" loop preload="auto" style="display:none">
     <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
     Your browser doesn’t support HTML5 audio.
   </audio>

--- a/Flask/Templates/save_as.html
+++ b/Flask/Templates/save_as.html
@@ -7,7 +7,7 @@
   </head>
   <body>
     <!-- Hidden, looping background music -->
-    <audio id="bgm" loop preload="auto" autoplay style="display:none">
+    <audio id="bgm" loop preload="auto" style="display:none">
       <source src="{{ url_for('static', filename='audio/escape-the-dungeon-dubious-dungeon.mp3') }}" type="audio/mpeg">
       Your browser doesn’t support HTML5 audio.
     </audio>


### PR DESCRIPTION
## Summary
- stop background music from autoplaying on every page
- ensure bgm.js script controls playback using stored preference

## Testing
- `python tests/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687ed41ea43c8320be5a844090c6b4be