### PR TITLE
Fix llm length form input handling

### DIFF
--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -106,6 +106,17 @@
       window.setBgmEnabled(toggle.checked);
       localStorage.setItem('bgmEnabled', toggle.checked);
     });
+
+    const llmInput = document.getElementById('llm_return_length');
+    llmInput.addEventListener('input', function() {
+      const min = parseInt(llmInput.min, 10);
+      const max = parseInt(llmInput.max, 10);
+      const val = parseInt(llmInput.value, 10);
+      if (!isNaN(val)) {
+        if (val < min) llmInput.value = min;
+        if (val > max) llmInput.value = max;
+      }
+    });
   });
 </script>
 {% endblock %}

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -208,7 +208,13 @@ def settings():
     if request.method == 'POST':
         diff      = request.form.get('difficulty')
         music     = request.form.get('music') == 'on'
-        llm_len   = int(request.form.get('llm_return_length', 50))
+        llm_val   = request.form.get('llm_return_length', '').strip()
+        try:
+            llm_len = int(llm_val)
+        except (TypeError, ValueError):
+            llm_len = session.get('settings', {}).get('llm_return_length', 50)
+        else:
+            llm_len = max(15, min(100, llm_len))
         voice     = request.form.get('voice') == 'on'
         map_size  = request.form.get('map_size')
         randomize = request.form.get('randomize_map') == 'on'


### PR DESCRIPTION
## Summary
- clamp numeric input for LLM output length in settings
- guard against invalid values in the settings route

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_687ed99582a8832093a60eab206ba8a7