### PR TITLE
Fix tts_langs import error

### DIFF
--- a/Game_Modules/voice.py
+++ b/Game_Modules/voice.py
@@ -3,6 +3,13 @@ import uuid
 from voicebox.voiceboxes import SimpleVoicebox
 from voicebox.sinks.wavefile import WaveFile
 
+try:
+    from gtts.lang import tts_langs
+except ImportError:
+    def tts_langs() -> dict:
+        """Fallback if gtts is missing."""
+        return {"en": "English"}
+
 try:  # voicebox's gTTS engine depends on the gtts package
     from voicebox.tts.gtts import gTTS as VoiceboxGTTS
 except ImportError as exc:


### PR DESCRIPTION
## Summary
- export `tts_langs` from `Game_Modules.voice`

## Testing
- `python tests/run_all_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687ee725aa8483209cdf4561d178c5e2