### PR TITLE
Enable Voicebox narration for enemy encounters

### DIFF
--- a/Game_Modules/game_utils.py
+++ b/Game_Modules/game_utils.py
@@ -106,6 +106,11 @@ def move_player(session, tgt_room, spawn_chance=0.6):
         session['enemy']     = e['name']
         session['encounter'] = e
 
+        # Generate audio for the enemy description if voice is enabled
+        if session.get('settings', {}).get('voice'):
+            voice_name = session.get('settings', {}).get('voice_name', 'en')
+            session['voice_audio'] = voice.generate_voice(e['llm_description'], voice_name)
+
         return f"<b>Enemy:</b> {e['name']} — {e['llm_description']}"
 
     # No spawn

--- a/tests/test_game_utils.py
+++ b/tests/test_game_utils.py
@@ -41,6 +41,15 @@ def test_move_player_spawn(monkeypatch):
     assert session['room_id'] == 'B'
     assert 'encounter' in session
 
+def test_move_player_spawn_voice(monkeypatch):
+    setup_basic(monkeypatch)
+    session = {'room_id': 'A', 'settings': {'voice': True, 'voice_name': 'en'}}
+    monkeypatch.setattr(random, 'random', lambda: 0.0)
+    monkeypatch.setattr(game_utils.voice, 'generate_voice', lambda t, l: 'audio.wav')
+    msg = game_utils.move_player(session, 'B', spawn_chance=1.0)
+    assert 'Enemy:' in msg
+    assert session['voice_audio'] == 'audio.wav'
+
 def test_move_player_no_spawn(monkeypatch):
     setup_basic(monkeypatch)
     session = {'room_id':'A'}


### PR DESCRIPTION
## Summary
- generate voice narration when enemies spawn
- test that narration triggers

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688290d62f308320afd63e2f11723c2d