### PR TITLE
Allow selectable character voices

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -209,7 +209,7 @@
 
 {% if audio_file %}
   <audio id="voicebox" autoplay>
-    <source src="{{ url_for('static', filename='voice/' + audio_file) }}" type="audio/wav">
+    <source src="{{ url_for('static', filename='voice/' + audio_file) }}" type="audio/mpeg">
   </audio>
   <script>
     const voiceAudio = document.getElementById('voicebox');

--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -55,7 +55,7 @@
       </li>
       <li>
         <label for="voice-name">
-          Voice Language:
+          Voice Character:
           <select id="voice-name" name="voice_name">
             {% for code, name in voice_choices.items() %}
               <option value="{{ code }}" {% if voice_name==code %}selected{% endif %}>{{ name }}</option>

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -24,14 +24,7 @@ from Game_Modules.game_utils import (
 
 from Game_Modules import rng, save_load
 from Game_Modules import voice
-
-try:
-    from gtts.lang import tts_langs
-except ImportError:
-    def tts_langs() -> dict:
-        """Fallback if gtts is missing."""
-        return {"en": "English"}
-from Game_Modules.voice import tts_langs
+from Game_Modules.voice import available_voices
 
 
 # Explicitly point Flask to the capitalized Templates directory so the
@@ -42,7 +35,7 @@ app.secret_key = os.urandom(24)
 
 # Precompute ROOM_NAMES mapping for templates
 ROOM_NAMES = {rid: get_room_name(rid) for rid in dungeon_map.rooms.keys()}
-VOICE_CHOICES = tts_langs()
+VOICE_CHOICES = available_voices()
 
 # ----- MAIN MENU -----
 @app.route('/')
@@ -67,7 +60,7 @@ def start_game():
     music     = settings.get('music', True)
     llm_len   = settings.get('llm_return_length', 50)
     voice     = settings.get('voice', False)
-    voice_name = settings.get('voice_name', 'en')
+    voice_name = settings.get('voice_name', 'default')
     map_size  = settings.get('map_size', 'Medium')
     randomize = settings.get('randomize_map', False)
     theme     = settings.get('display_theme', 'Standard')
@@ -230,7 +223,7 @@ def settings():
         else:
             llm_len = max(15, min(100, llm_len))
         voice     = request.form.get('voice') == 'on'
-        voice_name = request.form.get('voice_name', 'en')
+        voice_name = request.form.get('voice_name', 'default')
         map_size  = request.form.get('map_size')
         randomize = request.form.get('randomize_map') == 'on'
         theme     = request.form.get('display_theme')
@@ -257,7 +250,7 @@ def settings():
         music_enabled=s.get('music', True),
         llm_length=s.get('llm_return_length', 50),
         voice_enabled=s.get('voice', False),
-        voice_name=s.get('voice_name', 'en'),
+        voice_name=s.get('voice_name', 'default'),
         voice_choices=VOICE_CHOICES,
         map_size=s.get('map_size', 'Medium'),
         randomize_map=s.get('randomize_map', False),
@@ -324,7 +317,7 @@ def explore():
         if room_id not in visited:
             visited.append(room_id)
             session['visited'] = visited
-            voice_name = session.get('settings', {}).get('voice_name', 'en')
+            voice_name = session.get('settings', {}).get('voice_name', 'default')
             session['voice_audio'] = voice.generate_voice(room['llm_description'], voice_name)
 
     # 4.5) Generate/update minimap image for current position

--- a/Game_Modules/game_utils.py
+++ b/Game_Modules/game_utils.py
@@ -108,7 +108,7 @@ def move_player(session, tgt_room, spawn_chance=0.6):
 
         # Generate audio for the enemy description if voice is enabled
         if session.get('settings', {}).get('voice'):
-            voice_name = session.get('settings', {}).get('voice_name', 'en')
+            voice_name = session.get('settings', {}).get('voice_name', 'default')
             session['voice_audio'] = voice.generate_voice(e['llm_description'], voice_name)
 
         return f"<b>Enemy:</b> {e['name']} — {e['llm_description']}"
@@ -149,7 +149,7 @@ def search_room(session, search_chance=0.5):
 
         # Generate audio for item description if enabled
         if session.get('settings', {}).get('voice'):
-            voice_name = session.get('settings', {}).get('voice_name', 'en')
+            voice_name = session.get('settings', {}).get('voice_name', 'default')
             session['voice_audio'] = voice.generate_voice(found['llm_description'], voice_name)
 
         # Append to the player's inventory

--- a/Game_Modules/voice.py
+++ b/Game_Modules/voice.py
@@ -1,39 +1,82 @@
 import os
 import uuid
-from voicebox.voiceboxes import SimpleVoicebox
-from voicebox.sinks.wavefile import WaveFile
+import subprocess
+from typing import Dict
 
 try:
-    from gtts.lang import tts_langs
-except ImportError:
-    def tts_langs() -> dict:
-        """Fallback if gtts is missing."""
-        return {"en": "English"}
-
-try:  # voicebox's gTTS engine depends on the gtts package
-    from voicebox.tts.gtts import gTTS as VoiceboxGTTS
-except ImportError as exc:
-    VoiceboxGTTS = None
+    from gtts import gTTS
+except ImportError as exc:  # pragma: no cover - gtts is optional
+    gTTS = None
     _import_error = exc
 
-VOICE_DIR = os.path.join(os.path.dirname(__file__), '..', 'Flask', 'static', 'voice')
+from voicebox.voiceboxes import SimpleVoicebox
+from voicebox.sinks.wavefile import WaveFile
+from voicebox.tts.tts import WavFileTTS
 
+VOICE_DIR = os.path.join(os.path.dirname(__file__), '..', 'Flask', 'static', 'voice')
 os.makedirs(VOICE_DIR, exist_ok=True)
 
-def generate_voice(text: str, lang: str = 'en') -> str:
-    """Generate speech audio for the given text.
+VOICE_OPTIONS: Dict[str, str] = {
+    'default': 'Default',
+    'glados': 'GLaDOS',
+}
 
-    Returns the relative filename of the generated WAV file under
-    ``static/voice``.
-    """
-    if VoiceboxGTTS is None:
+def available_voices() -> Dict[str, str]:
+    """Return mapping of selectable voice identifiers to display names."""
+    return VOICE_OPTIONS
+
+
+class _GTTSWavTTS(WavFileTTS):
+    """Minimal TTS engine that outputs a WAV file using gTTS and ffmpeg."""
+
+    def __init__(self) -> None:
+        # WavFileTTS requires temp file args but we don't need custom paths
+        super().__init__(None, "gtts")
+
+    def generate_speech_audio_file(self, text: str, audio_file_path: str) -> None:
+        tmp_mp3 = f"{audio_file_path}.mp3"
+        gTTS(text=text).save(tmp_mp3)
+        subprocess.run(
+            ['ffmpeg', '-y', '-loglevel', 'error', '-i', tmp_mp3, audio_file_path],
+            check=True,
+        )
+        os.remove(tmp_mp3)
+
+def _ensure_gtts():
+    if gTTS is None:  # pragma: no cover - raised only when dependency missing
         raise RuntimeError(
             "gtts package is required for speech output; install it with 'pip install gtts'"
         ) from _import_error
 
-    filename = f"{uuid.uuid4().hex}.wav"
-    path = os.path.join(VOICE_DIR, filename)
-    tts_engine = VoiceboxGTTS(lang=lang)
-    vb = SimpleVoicebox(tts=tts_engine, sink=WaveFile(path))
+
+def _glados_voice(text: str, out_mp3: str) -> None:
+    """Generate audio using the built-in GLaDOS character."""
+    from voicebox.examples import glados
+
+    wav_path = out_mp3 + '.wav'
+    vb = SimpleVoicebox(
+        tts=_GTTSWavTTS(),
+        effects=glados.build_glados_effects(),
+        sink=WaveFile(wav_path),
+    )
     vb.say(text)
+    subprocess.run([
+        'ffmpeg', '-y', '-loglevel', 'error', '-i', wav_path, out_mp3
+    ], check=True)
+    os.remove(wav_path)
+
+
+def generate_voice(text: str, voice: str = 'default') -> str:
+    """Generate speech audio for the given text using the selected voice."""
+    _ensure_gtts()
+
+    filename = f"{uuid.uuid4().hex}.mp3"
+    path = os.path.join(VOICE_DIR, filename)
+
+    if voice.lower() == 'glados':
+        _glados_voice(text, path)
+    else:
+        tts = gTTS(text=text)
+        tts.save(path)
+
     return filename

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 A text based dungeon crawler using Qwen for dynamic descriptions for rooms, items and npc dialog
 
-dependencies
+Dependencies
 
+```
 pip install flask networkx matplotlib pillow pytest voicebox-tts gtts "transformers[torch]" .[torch]
+```
 
-must allow auto play in browser for audio
+You will also need ``ffmpeg`` installed for applying voice effects.
+
+Audio narration saves MP3 files in ``Flask/static/voice``. The voice can be
+changed in the game settings. Available options are "Default" and the
+"GLaDOS" character voice. Ensure your browser allows autoplay of audio.

--- a/tests/test_game_utils.py
+++ b/tests/test_game_utils.py
@@ -43,7 +43,7 @@ def test_move_player_spawn(monkeypatch):
 
 def test_move_player_spawn_voice(monkeypatch):
     setup_basic(monkeypatch)
-    session = {'room_id': 'A', 'settings': {'voice': True, 'voice_name': 'en'}}
+    session = {'room_id': 'A', 'settings': {'voice': True, 'voice_name': 'default'}}
     monkeypatch.setattr(random, 'random', lambda: 0.0)
     monkeypatch.setattr(game_utils.voice, 'generate_voice', lambda t, l: 'audio.wav')
     msg = game_utils.move_player(session, 'B', spawn_chance=1.0)


### PR DESCRIPTION
## Summary
- add GLaDOS voice option powered by voicebox
- expose available_voices() for settings
- update Flask templates and session defaults
- document ffmpeg requirement and character voices
- fix glados voice generation using custom gTTS-based TTS
- fix voicebox TTS initialization

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688294422a088320872d7bcc7b329a31