### PR TITLE
Fix voice generation initialization

### DIFF
--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -59,7 +59,7 @@ def start_game():
     diff      = form_diff or settings.get('difficulty', 'Normal')
     music     = settings.get('music', True)
     llm_len   = settings.get('llm_return_length', 50)
-    voice     = settings.get('voice', False)
+    voice     = settings.get('voice', True)
     voice_name = settings.get('voice_name', 'default')
     map_size  = settings.get('map_size', 'Medium')
     randomize = settings.get('randomize_map', False)
@@ -249,7 +249,7 @@ def settings():
         current=s.get('difficulty', 'Normal'),
         music_enabled=s.get('music', True),
         llm_length=s.get('llm_return_length', 50),
-        voice_enabled=s.get('voice', False),
+        voice_enabled=s.get('voice', True),
         voice_name=s.get('voice_name', 'default'),
         voice_choices=VOICE_CHOICES,
         map_size=s.get('map_size', 'Medium'),

--- a/Flask/static/style.css
+++ b/Flask/static/style.css
@@ -298,6 +298,10 @@ input[type="text"], input[type="number"], select {
   box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.3);
 }
 
+select option {
+  color: black;
+}
+
 input[type="text"]:focus, input[type="number"]:focus, select:focus {
   border-color: var(--accent);
   box-shadow: 

--- a/Game_Modules/voice.py
+++ b/Game_Modules/voice.py
@@ -29,6 +29,9 @@ def available_voices() -> Dict[str, str]:
 class _GTTSWavTTS(WavFileTTS):
     """Minimal TTS engine that outputs a WAV file using gTTS and ffmpeg."""
 
+    def __init__(self) -> None:
+        super().__init__(None, "gtts_")
+
     def generate_speech_audio_file(self, text: str, audio_file_path: str) -> None:
         tmp_mp3 = f"{audio_file_path}.mp3"
         gTTS(text=text, lang='en').save(tmp_mp3)


### PR DESCRIPTION
## Summary
- initialize custom gTTS voice class correctly
- enable voice narration by default
- dark theme overrides: black text for dropdown options

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6882a370ff60832080b11f1baa26e484