### PR TITLE
Handle missing ffmpeg in voice module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Dependencies
 ```
 pip install flask networkx matplotlib pillow pytest voicebox-tts gtts "transformers[torch]" .[torch]
 
-You will also need ffmpeg installed for applying voice effects.
+You will also need ffmpeg installed and available on your PATH for applying the
+GLaDOS voice effects.
 
 Audio narration saves MP3 files in ``Flask/static/voice``. The voice can be
 changed in the game settings. Available options are "Default" and the


### PR DESCRIPTION
## Summary
- add a helper to check for `ffmpeg`
- use the helper when converting audio
- clarify in README that the GLaDOS voice requires `ffmpeg`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_6882a54b68348320a4e428d8c0f33db2