### PR TITLE
Enhance UI and add GPU option

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -96,7 +96,9 @@
           <div class="stat-icon">✨</div>
           <div class="stat-content">
             <div class="stat-label">Experience</div>
-            <div class="stat-value">{{ xp }}</div>
+            <div class="stat-value">{{ xp }}
+              <span class="stat-extra">{{ xp_to_next }} to next</span>
+            </div>
           </div>
           <div class="stat-bar">
             <div class="stat-fill xp-fill" style="width: {{ ((xp % 100) / 100 * 100)|round }}%"></div>
@@ -386,6 +388,11 @@
   font-size: 0.8rem;
   font-weight: bold;
   color: var(--text-light);
+}
+.stat-extra {
+  font-size: 0.6rem;
+  color: #aaa;
+  margin-left: 0.25rem;
 }
 
 .stat-bar {

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -461,7 +461,11 @@
   font-weight: bold;
   color: white;
   text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
-  position: relative;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  text-align: center;
   z-index: 2;
 }
 

--- a/Flask/Templates/inventory.html
+++ b/Flask/Templates/inventory.html
@@ -54,7 +54,9 @@
           <div class="stat-icon">✨</div>
           <div class="stat-info">
             <div class="stat-label">Experience</div>
-            <div class="stat-value">{{ player.xp }}</div>
+            <div class="stat-value">{{ player.xp }}
+              <span class="stat-extra">{{ xp_to_next }} to next</span>
+            </div>
           </div>
         </div>
       </div>
@@ -152,6 +154,13 @@
                       <span class="stat-value">{{ item.speed }}</span>
                     </div>
                   {% endif %}
+                </div>
+              {% else %}
+                <div class="item-stats">
+                  <div class="stat-line health">
+                    <span class="stat-icon">❤️</span>
+                    <span class="stat-value">{{ item.health }}</span>
+                  </div>
                 </div>
               {% endif %}
             </div>
@@ -338,6 +347,11 @@
   font-size: 1.2rem;
   font-weight: bold;
   color: var(--text-light);
+}
+.stat-extra {
+  font-size: 0.7rem;
+  color: #aaa;
+  margin-left: 0.25rem;
 }
 
 .equipment-section, .inventory-section {

--- a/Flask/Templates/menu.html
+++ b/Flask/Templates/menu.html
@@ -88,15 +88,9 @@
             <span class="label-text">Difficulty:</span>
           </label>
           <select id="difficulty" name="difficulty">
-            <option value="Easy" {% if current=='Easy' %}selected{% endif %}>
-              🟢 Easy - More health, safer exploration
-            </option>
-            <option value="Normal" {% if current=='Normal' %}selected{% endif %}>
-              🟡 Normal - Balanced challenge
-            </option>
-            <option value="Hard" {% if current=='Hard' %}selected{% endif %}>
-              🔴 Hard - Brutal difficulty for experts
-            </option>
+            <option value="Easy" {% if current=='Easy' %}selected{% endif %}>🟢 Easy - Safe</option>
+            <option value="Normal" {% if current=='Normal' %}selected{% endif %}>🟡 Normal - Balanced</option>
+            <option value="Hard" {% if current=='Hard' %}selected{% endif %}>🔴 Hard - Brutal</option>
           </select>
         </div>
       </div>
@@ -410,6 +404,8 @@
   font-family: inherit;
   font-size: 0.9rem;
   transition: all 0.3s ease;
+  text-align: center;
+  text-align-last: center;
 }
 
 .input-group input:focus, .input-group select:focus {

--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -43,6 +43,15 @@
         </label>
       </li>
       <li>
+        <label for="llm-device">
+          LLM Device:
+          <select id="llm-device" name="llm_device">
+            <option value="cpu" {% if llm_device=='cpu' %}selected{% endif %}>CPU</option>
+            <option value="gpu" {% if llm_device=='gpu' %}selected{% endif %}>GPU</option>
+          </select>
+        </label>
+      </li>
+      <li>
         <label for="voice-toggle">
           Voice:
           <input

--- a/Game_Modules/llm_client.py
+++ b/Game_Modules/llm_client.py
@@ -116,8 +116,17 @@ def _get_llm_pipeline(device: int = None):
         device=device
     )
 
-# Lazy‐initialized singleton
+# Lazy‐initialized singleton and device choice
 _LLM = None
+_DEVICE = None
+
+def set_device(choice: str | None):
+    """Set the preferred device ('cpu' or 'gpu')."""
+    global _DEVICE, _LLM
+    new = 0 if choice == 'gpu' else None
+    if new != _DEVICE:
+        _DEVICE = new
+        _LLM = None
 
 def generate_description(kind: str, context: dict, max_new_tokens: int = 120) -> str:
     """
@@ -125,9 +134,9 @@ def generate_description(kind: str, context: dict, max_new_tokens: int = 120) ->
     context: dict with fields relevant to that kind.
     Returns a single, concise, one-sentence description.
     """
-    global _LLM
+    global _LLM, _DEVICE
     if _LLM is None:
-        _LLM = _get_llm_pipeline(device=None)
+        _LLM = _get_llm_pipeline(device=_DEVICE)
 
     # Build a clear one-sentence prompt (no Markdown)
     if kind == 'gear':


### PR DESCRIPTION
## Summary
- add LLM device selector and hook into llm_client
- show XP needed for next level in exploration and inventory screens
- display healing amount for aid items
- center select box text and shorten difficulty labels
- center health text in fight bars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882dc45eaac8320912f3f2755365e6b