### PR TITLE
Adjust stats boxes to fit content

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -343,8 +343,8 @@
 }
 
 .stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
@@ -353,6 +353,7 @@
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 1rem;
+  width: fit-content;
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -598,7 +599,7 @@
   }
   
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    justify-content: center;
   }
 }
 
@@ -608,8 +609,8 @@
   }
   
   .stats-grid {
-    grid-template-columns: 1fr 1fr;
     gap: 0.5rem;
+    justify-content: center;
   }
   
   .stat-item {

--- a/Flask/Templates/inventory.html
+++ b/Flask/Templates/inventory.html
@@ -297,8 +297,8 @@
 }
 
 .stats-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
 }
 
@@ -307,6 +307,7 @@
   align-items: center;
   gap: 1rem;
   padding: 1rem;
+  width: fit-content;
   background: var(--panel-dark);
   border: 2px solid var(--border-color);
   border-radius: 10px;
@@ -729,7 +730,7 @@
 /* Responsive design */
 @media (max-width: 1024px) {
   .stats-grid {
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    justify-content: center;
   }
   
   .equipment-grid {
@@ -748,8 +749,8 @@
   }
   
   .stats-grid {
-    grid-template-columns: 1fr 1fr;
     gap: 1rem;
+    justify-content: center;
   }
   
   .equipment-grid {


### PR DESCRIPTION
## Summary
- tweak player stats grid styles to flex-wrap and fit content
- ensure stats items size to content in exploration and inventory views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882df9147888320a09d4fe11dde2c5b