### PR TITLE
Ensure Flask server stops on page exit

### DIFF
--- a/Flask/Templates/base.html
+++ b/Flask/Templates/base.html
@@ -351,6 +351,11 @@
       console.log('🏰 Dungeon Crawler Enhanced UI Loaded Successfully! 🗡️');
     });
 
+    // Attempt to shut down the server when leaving the page
+    window.addEventListener('pagehide', () => {
+      navigator.sendBeacon("{{ url_for('shutdown') }}");
+    });
+
     // Global utility functions
     window.dungeonUtils = {
       showNotification: (message, type = 'info') => {

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -627,5 +627,14 @@ def inventory_route():
 def loading():
     return render_template('loading.html'), 202
 
+# --- Shutdown Route ---
+@app.route('/shutdown', methods=['POST'])
+def shutdown():
+    """Terminate the Flask development server."""
+    func = request.environ.get('werkzeug.server.shutdown')
+    if func:
+        func()
+    return '', 204
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -55,3 +55,7 @@ def test_start_game_difficulty_form(client, diff, expected):
 def test_rng_route(client):
     resp = client.get('/rng?min=1&max=10')
     assert resp.data.strip() == b'5'
+
+def test_shutdown(client):
+    resp = client.post('/shutdown')
+    assert resp.status_code == 204


### PR DESCRIPTION
## Summary
- add a shutdown route in `flask_app.py`
- send a beacon to the shutdown route on page exit
- test the new route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e14d13fc83209131170de655e7f2