### PR TITLE
Fix SPA form handling

### DIFF
--- a/Flask/static/spa.js
+++ b/Flask/static/spa.js
@@ -26,7 +26,9 @@
 
   document.addEventListener('submit', e => {
     const form = e.target.closest('form');
-    if (form && form.getAttribute('action') && form.getAttribute('action') !== '/save_as' && form.getAttribute('action') !== '/save-as') {
+    if (!form) return;
+    const path = new URL(form.action, window.location.href).pathname;
+    if (path !== '/save_as' && path !== '/save-as') {
       e.preventDefault();
       const data = new FormData(form);
       fetchAndReplace(form.action, { method: form.method || 'GET', body: data });


### PR DESCRIPTION
## Summary
- intercept forms without explicit action in spa.js to avoid page reloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e92904948320a224101d40dec87d