### PR TITLE
Fix SPA form submit to include clicked button

### DIFF
--- a/Flask/static/spa.js
+++ b/Flask/static/spa.js
@@ -41,14 +41,15 @@
       const method = (form.method || 'GET').toUpperCase();
       let url = form.action || window.location.href;
       const opts = { method, credentials: 'same-origin' };
+      const data = new FormData(form);
+      if (e.submitter && e.submitter.name) {
+        data.append(e.submitter.name, e.submitter.value);
+      }
       if (method === 'GET') {
-        const params = new URLSearchParams();
-        for (const [key, value] of new FormData(form).entries()) {
-          params.append(key, value);
-        }
+        const params = new URLSearchParams(data);
         url += (url.includes('?') ? '&' : '?') + params.toString();
       } else {
-        opts.body = new FormData(form);
+        opts.body = data;
       }
       fetchAndReplace(url, opts);
     }


### PR DESCRIPTION
## Summary
- include the clicked submit button when intercepting forms in `spa.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f06244a48320bed0cf148dd63249