### PR TITLE
Fix SPA buttons for search and movement

### DIFF
--- a/Flask/static/spa.js
+++ b/Flask/static/spa.js
@@ -1,4 +1,6 @@
 (() => {
+  let lastSubmitter = null;
+
   function fetchAndReplace(url, options) {
     if (window.startLoading) window.startLoading();
     fetch(url, options).then(r => r.text()).then(html => {
@@ -16,6 +18,11 @@
   }
 
   document.addEventListener('click', e => {
+    const btn = e.target.closest('button');
+    if (btn && btn.type !== 'button') {
+      lastSubmitter = btn;
+    }
+
     const a = e.target.closest('a');
     if (a && a.getAttribute('href') && a.getAttribute('href').startsWith('/') &&
         a.getAttribute('href') !== '/save_as' && a.getAttribute('href') !== '/save-as') {
@@ -42,9 +49,11 @@
       let url = form.action || window.location.href;
       const opts = { method, credentials: 'same-origin' };
       const data = new FormData(form);
-      if (e.submitter && e.submitter.name) {
-        data.append(e.submitter.name, e.submitter.value);
+      const submitter = e.submitter || lastSubmitter;
+      if (submitter && submitter.name) {
+        data.append(submitter.name, submitter.value);
       }
+      lastSubmitter = null;
       if (method === 'GET') {
         const params = new URLSearchParams(data);
         url += (url.includes('?') ? '&' : '?') + params.toString();


### PR DESCRIPTION
## Summary
- ensure SPA captures submit buttons in `spa.js`
- reset recorded button after request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f210fc6c832085d772c6bbf55554