### PR TITLE
Fix SPA history after redirects

### DIFF
--- a/Flask/static/spa.js
+++ b/Flask/static/spa.js
@@ -14,7 +14,7 @@
       if (!main) { window.location.href = finalUrl; return; }
       document.getElementById('content').innerHTML = main.innerHTML;
       document.title = doc.title;
-      window.history.pushState({url: finalUrl}, '', finalUrl);
+      window.history.pushState({finalUrl}, '', finalUrl);
       if (window.endLoading) {
         window.endLoading();
       }

--- a/Flask/static/spa.js
+++ b/Flask/static/spa.js
@@ -5,14 +5,16 @@
     if (window.startLoading) {
       window.startLoading();
     }
-    fetch(url, options).then(r => r.text()).then(html => {
+    fetch(url, options).then(async r => {
+      const html = await r.text();
+      const finalUrl = r.url;
       const parser = new DOMParser();
       const doc = parser.parseFromString(html, 'text/html');
       const main = doc.getElementById('content');
-      if (!main) { window.location.href = url; return; }
+      if (!main) { window.location.href = finalUrl; return; }
       document.getElementById('content').innerHTML = main.innerHTML;
       document.title = doc.title;
-      window.history.pushState({url}, '', url);
+      window.history.pushState({url: finalUrl}, '', finalUrl);
       if (window.endLoading) {
         window.endLoading();
       }


### PR DESCRIPTION
## Summary
- keep SPA URL in sync with redirects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f451e2808320b696836a5c5574bc