### PR TITLE
Implement map randomization and minimap settings

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <div class="game-flex">
+  {% if show_minimap %}
   <!-- Enhanced Minimap Section -->
   <div class="minimap-container">
     <div class="minimap-header">
@@ -24,6 +25,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
 
   <!-- Main Game Content -->
   <div class="game-container">
@@ -592,6 +594,7 @@
     flex-direction: column;
     gap: 2rem;
     margin: 1rem;
+    align-items: center;
   }
   
   .minimap-container {
@@ -628,6 +631,9 @@
   
   .menu-actions {
     flex-direction: column;
+  }
+  .game-flex {
+    align-items: center;
   }
 }
 </style>

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -27,10 +27,9 @@
       <div class="health-section">
         <div class="health-label">Health</div>
         <div class="health-bar">
-          <div class="health-fill player-health" 
-               style="width: {{ (player.hp / 100 * 100)|round }}%">
-            <span class="health-text">{{ player.hp }} HP</span>
-          </div>
+          <div class="health-fill player-health"
+               style="width: {{ (player.hp / 100 * 100)|round }}%"></div>
+          <span class="health-text">{{ player.hp }} HP</span>
         </div>
       </div>
       
@@ -75,10 +74,9 @@
       <div class="health-section">
         <div class="health-label">Health</div>
         <div class="health-bar">
-          <div class="health-fill enemy-health" 
-               style="width: {{ (enemy.current_hp / enemy.max_hp * 100)|round }}%">
-            <span class="health-text">{{ enemy.current_hp }} / {{ enemy.max_hp }} HP</span>
-          </div>
+          <div class="health-fill enemy-health"
+               style="width: {{ (enemy.current_hp / enemy.max_hp * 100)|round }}%"></div>
+          <span class="health-text">{{ enemy.current_hp }} / {{ enemy.max_hp }} HP</span>
         </div>
       </div>
       

--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -94,6 +94,17 @@
         </label>
       </li>
       <li>
+        <label for="hide-minimap">
+          Hide Minimap:
+          <input
+            type="checkbox"
+            id="hide-minimap"
+            name="hide_minimap"
+            {% if hide_minimap %}checked{% endif %}
+          >
+        </label>
+      </li>
+      <li>
         <label for="display-theme">
           Display Theme:
           <select id="display-theme" name="display_theme">

--- a/Game_Modules/map.py
+++ b/Game_Modules/map.py
@@ -1,3 +1,6 @@
+import random
+
+
 class DungeonMap:
     def __init__(self, map_data):
         """
@@ -19,9 +22,9 @@ class DungeonMap:
             self.rooms = rooms
 
     def is_valid_move(self, current_room, target_room):
-        """
-        Return True if `target_room` is a neighbor of `current_room`.
-        """
+        """Return True if ``target_room`` is a valid enabled neighbour."""
+        if self.rooms.get(target_room, {}).get('disabled'):
+            return False
         neighbors = self.rooms.get(current_room, {}).get('neighbors', [])
         return target_room in neighbors
 
@@ -30,3 +33,21 @@ class DungeonMap:
         Return a list of neighbor room IDs for `room_id`, or an empty list.
         """
         return list(self.rooms.get(room_id, {}).get('neighbors', []))
+
+    def randomize_rooms(self, start_room=None, pct=0.3):
+        """Randomly disable rooms except ``start_room`` and cleanup neighbors."""
+        for r in self.rooms.values():
+            r.pop('disabled', None)
+
+        if start_room is None:
+            start_room = next(iter(self.rooms))
+
+        for rid, room in self.rooms.items():
+            if rid == start_room:
+                continue
+            if random.random() < pct:
+                room['disabled'] = True
+
+        for room in self.rooms.values():
+            room['neighbors'] = [n for n in room.get('neighbors', [])
+                                 if not self.rooms.get(n, {}).get('disabled')]


### PR DESCRIPTION
## Summary
- randomize rooms in `DungeonMap` and check if enabled
- add option to hide the minimap and disable it when the map is randomized
- center minimap layout on small screens
- fix healing item usage and center health text
- rework XP gain formula

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882fb4eed2c83209d37c8eeced51868