### PR TITLE
Fix map randomization connectivity and LLM init

### DIFF
--- a/Game_Modules/llm_client.py
+++ b/Game_Modules/llm_client.py
@@ -123,7 +123,7 @@ def _get_llm_pipeline(device: int = None):
     return pipeline(
         "text-generation",
         model=MODEL_NAME,
-        device=device
+        device_map="auto"
     )
 
 # Lazy‐initialized singleton and device choice


### PR DESCRIPTION
## Summary
- keep dungeon map connected when rooms are randomized
- initialize text generation pipeline with `device_map="auto"`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688301a9f1948320bc1bac8f4a49e1f1