### PR TITLE
Improve leveling, health bar and map reset

### DIFF
--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -28,8 +28,8 @@
         <div class="health-label">Health</div>
         <div class="health-bar">
           <div class="health-fill player-health"
-               style="width: {{ (player.hp / 100 * 100)|round }}%"></div>
-          <span class="health-text">{{ player.hp }} HP</span>
+               style="width: {{ (player.hp / player.max_hp * 100)|round }}%"></div>
+          <span class="health-text">{{ player.hp }} / {{ player.max_hp }} HP</span>
         </div>
       </div>
       

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -346,13 +346,15 @@ def explore():
         'speed':   sum(i.get('speed',0)   for i in eq.values() if i),
     }
     from Game_Modules.entities import Player
+    max_hp = player_template.get('stats', {}).get('max_health', 100)
     player = Player(
         session['player_name'],
         base.get('attack',1)  + bonus['attack'],
         base.get('defense',1) + bonus['defense'],
         base.get('speed',1)   + bonus['speed'],
         session.get('level',1),
-        session.get('xp',0)
+        session.get('xp',0),
+        max_hp
     )
     player.hp = session.get('hp', player.hp)
 
@@ -446,13 +448,15 @@ def fight():
     # Rebuild the player
     base = player_template.get('stats', {'attack':10,'defense':5,'speed':5})
     bonus = {k: sum(item.get(k,0) for item in session['equipped'].values() if item) for k in base}
+    max_hp = player_template.get('stats', {}).get('max_health', 100)
     player = Player(
         session['player_name'],
         base['attack']  + bonus['attack'],
         base['defense'] + bonus['defense'],
         base['speed']   + bonus['speed'],
         session['level'],
-        session['xp']
+        session['xp'],
+        max_hp
     )
     player.hp = session['hp']
 

--- a/Game_Modules/entities.py
+++ b/Game_Modules/entities.py
@@ -1,12 +1,13 @@
 class Player:
-    def __init__(self, name, attack=0, defense=0, speed=0, level=1, xp=0):
+    def __init__(self, name, attack=0, defense=0, speed=0, level=1, xp=0, max_hp=100):
         self.name = name
         self.attack = attack
         self.defense = defense
         self.speed = speed
         self.level = level
         self.xp = xp
-        self.hp = 100
+        self.max_hp = max_hp
+        self.hp = max_hp
 
     def take_damage(self, amt):
         self.hp = max(0, self.hp - amt)
@@ -21,7 +22,8 @@ class Enemy:
         self.attack = stats.get("attack", 0)
         self.defense = stats.get("defense", 0)
         self.speed = stats.get("speed", 0)
-        self.hp = 50 + (level * 10)
+        self.max_hp = 50 + (level * 10)
+        self.hp = self.max_hp
 
     def take_damage(self, amt):
         self.hp = max(0, self.hp - amt)

--- a/Game_Modules/game_utils.py
+++ b/Game_Modules/game_utils.py
@@ -45,13 +45,15 @@ def rebuild_player(session, player_template):
     bonuses = { stat: sum(item.get(stat,0)
                    for item in session['equipped'].values() if item)
                for stat in base }
+    max_hp = player_template.get('stats', {}).get('max_health', 100)
     p = Player(
         session['player_name'],
         base['attack']  + bonuses['attack'],
         base['defense'] + bonuses['defense'],
         base['speed']   + bonuses['speed'],
         session['level'],
-        session['xp']
+        session['xp'],
+        max_hp
     )
     p.hp = session['hp']
     return p

--- a/Game_Modules/leveling.py
+++ b/Game_Modules/leveling.py
@@ -17,6 +17,14 @@ def xp_threshold(level):
     """
     return float('inf') if level >= 11 else 100 * math.log(10 / (11 - level))
 
+
+def _stat_gain(next_level, current_stat):
+    """Return stat increase for reaching ``next_level`` from the previous one."""
+    xp_needed = xp_threshold(next_level) - xp_threshold(next_level - 1)
+    base = 1 if xp_needed in (0, float('inf')) else math.ceil(100 / xp_needed)
+    rand_max = max(1, math.ceil(current_stat / 4))
+    return base + random.randint(1, rand_max)
+
 def process_level(total_xp):
     assets = import_assets('new')
     player = assets['player_template']
@@ -29,9 +37,10 @@ def process_level(total_xp):
 
     # if leveled up, grant random stats
     if new_level > current_level:
-        for _ in range(new_level - current_level):
+        for lvl in range(current_level + 1, new_level + 1):
             for stat in ('attack', 'defense', 'speed', 'current_health', 'max_health'):
-                player[stat] = player.get(stat, 0) + random.randint(1, 3)
+                cur = player.get(stat, 0)
+                player[stat] = cur + _stat_gain(lvl, cur)
         player['level'] = new_level
 
     player['xp'] = total_xp
@@ -47,7 +56,7 @@ def apply_leveling(session, player_template):
         new_level += 1
 
     if new_level > current_level:
-        for _ in range(new_level - current_level):
+        for lvl in range(current_level + 1, new_level + 1):
             for stat in (
                 'attack',
                 'defense',
@@ -57,9 +66,11 @@ def apply_leveling(session, player_template):
             ):
                 if 'stats' in player_template:
                     stats = player_template.setdefault('stats', {})
-                    stats[stat] = stats.get(stat, 0) + random.randint(1, 3)
+                    cur = stats.get(stat, 0)
+                    stats[stat] = cur + _stat_gain(lvl, cur)
                 else:
-                    player_template[stat] = player_template.get(stat, 0) + random.randint(1, 3)
+                    cur = player_template.get(stat, 0)
+                    player_template[stat] = cur + _stat_gain(lvl, cur)
         session['level'] = new_level
         max_hp = player_template.get('stats', {}).get('max_health', session.get('hp', 0))
         session['hp'] = min(session.get('hp', max_hp), max_hp)

--- a/Game_Modules/map.py
+++ b/Game_Modules/map.py
@@ -20,6 +20,8 @@ class DungeonMap:
                 if key := room.get('id') or room.get('room_id'):
                     rooms[key] = room
             self.rooms = rooms
+        self._orig_neighbors = {rid: list(r.get('neighbors', []))
+                                for rid, r in self.rooms.items()}
 
     def is_valid_move(self, current_room, target_room):
         """Return True if ``target_room`` is a valid enabled neighbour."""
@@ -36,8 +38,9 @@ class DungeonMap:
 
     def randomize_rooms(self, start_room=None, pct=0.3):
         """Randomly disable rooms while keeping the map connected."""
-        for r in self.rooms.values():
+        for rid, r in self.rooms.items():
             r.pop('disabled', None)
+            r['neighbors'] = list(self._orig_neighbors.get(rid, []))
 
         if start_room is None:
             start_room = next(iter(self.rooms))


### PR DESCRIPTION
## Summary
- restore original neighbor lists when randomizing rooms
- show current/max health for the player
- add max_hp to Player and Enemy classes
- compute level-up bonuses using inverse XP curve

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688305a615dc83208770891585ea3ae7