### PR TITLE
Fix missing movement options

### DIFF
--- a/Game_Modules/map.py
+++ b/Game_Modules/map.py
@@ -71,3 +71,13 @@ class DungeonMap:
         for room in self.rooms.values():
             room['neighbors'] = [n for n in room.get('neighbors', [])
                                  if not self.rooms.get(n, {}).get('disabled')]
+
+        # Ensure the starting room has at least one available neighbour
+        if not self.get_neighbors(start_room):
+            choices = [n for n in self._orig_neighbors.get(start_room, [])]
+            if choices:
+                chosen = random.choice(choices)
+                self.rooms[chosen].pop('disabled', None)
+                for room in self.rooms.values():
+                    room['neighbors'] = [n for n in room.get('neighbors', [])
+                                         if not self.rooms.get(n, {}).get('disabled')]


### PR DESCRIPTION
## Summary
- ensure starting room always retains at least one neighbor when maps are randomized

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688309dfdfb8832099ebe50ed3d75542