### PR TITLE
Add victory page and UI tweaks

### DIFF
--- a/Flask/Templates/complete.html
+++ b/Flask/Templates/complete.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block title %}Dungeon Cleared{% endblock %}
+
+{% block content %}
+<div class="container" style="text-align:center;padding:2rem;">
+  <h1>🎉 Dungeon Cleared! 🎉</h1>
+  <p>You defeated an enemy in every room.</p>
+  <a href="{{ url_for('menu') }}" class="button">Return to Menu</a>
+</div>
+{% endblock %}

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -460,11 +460,13 @@
   color: white;
   text-shadow: 0 0 3px rgba(0, 0, 0, 0.8);
   position: absolute;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   width: 100%;
   text-align: center;
   z-index: 2;
+  pointer-events: none;
 }
 
 .combat-stats {

--- a/Flask/Templates/settings.html
+++ b/Flask/Templates/settings.html
@@ -83,17 +83,6 @@
         </label>
       </li>
       <li>
-        <label for="randomize-map">
-          Randomize Map:
-          <input
-            type="checkbox"
-            id="randomize-map"
-            name="randomize_map"
-            {% if randomize_map %}checked{% endif %}
-          >
-        </label>
-      </li>
-      <li>
         <label for="hide-minimap">
           Hide Minimap:
           <input

--- a/Game_Modules/Game_Assets/Templates/settings-template.json
+++ b/Game_Modules/Game_Assets/Templates/settings-template.json
@@ -4,6 +4,5 @@
   "llm_return_length": 150,
   "voice": "on",
   "map_size": "Medium",
-  "randomize_map": "Off",
   "display_theme": "Standard"
 }

--- a/Game_Modules/MiniMap.py
+++ b/Game_Modules/MiniMap.py
@@ -11,7 +11,8 @@ MINIMAP_PATH = os.path.join(os.path.dirname(__file__), '../Textures/mini-map.png
 
 def generate_minimap(player_x, player_y, view_width=1500, view_height=1000, marker_radius=5, output_path=None):
     """
-    Crops the mini-map so the player is centered, overlays a marker at the center, and saves/returns the image.
+    Crops the mini-map so the player is centered when possible, overlays a marker
+    at the player's location within the cropped view, and saves/returns the image.
     Args:
         player_x, player_y: Player's position on the map image (in pixels)
         view_width, view_height: Size of the cropped view (in pixels)
@@ -38,13 +39,13 @@ def generate_minimap(player_x, player_y, view_width=1500, view_height=1000, mark
 
     cropped = minimap.crop((left, upper, right, lower))
 
-    # Draw marker at center
+    # Draw marker at the player's coordinates relative to the crop
     draw = ImageDraw.Draw(cropped)
-    center_x = view_width // 2
-    center_y = view_height // 2
+    draw_x = player_x - left
+    draw_y = player_y - upper
     draw.ellipse([
-        (center_x - marker_radius, center_y - marker_radius),
-        (center_x + marker_radius, center_y + marker_radius)
+        (draw_x - marker_radius, draw_y - marker_radius),
+        (draw_x + marker_radius, draw_y + marker_radius)
     ], fill='red', outline='black')
 
     if output_path is None:


### PR DESCRIPTION
## Summary
- center health text in fight bars
- track cleared rooms and show complete page when all are cleared
- remove map randomization support
- place minimap marker on exact room

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68830ea28f888320a09289c8b0115bdf