### PR TITLE
Fix minimap caching

### DIFF
--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -50,7 +50,7 @@ def minimap_png():
     if not os.path.exists(path):
         from flask import abort
         abort(404, description="Minimap image not found.")
-    return send_file(path, mimetype='image/png')
+    return send_file(path, mimetype='image/png', max_age=0)
 
 # Precompute ROOM_NAMES mapping for templates
 ROOM_NAMES = {rid: get_room_name(rid) for rid in dungeon_map.rooms.keys()}

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -59,3 +59,11 @@ def test_rng_route(client):
 def test_shutdown(client):
     resp = client.post('/shutdown')
     assert resp.status_code == 204
+
+def test_minimap_caching(client):
+    client.post('/start', data={'name': 'Hero'})
+    client.get('/explore')
+    resp = client.get('/minimap.png')
+    assert resp.status_code == 200
+    cache_control = resp.headers.get('Cache-Control', '')
+    assert 'max-age=0' in cache_control


### PR DESCRIPTION
## Summary
- disable browser caching for `minimap.png`
- test that `/minimap.png` returns a no-cache header

## Testing
- `pip install flask networkx matplotlib pillow pytest gtts`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688312e600a48320bceff45630066975