### PR TITLE
Improve minimap zoom

### DIFF
--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -398,7 +398,8 @@ def explore():
         width, height = size_map.get(settings.get('map_size', 'Medium'), (300, 600))
         _, marker_x, marker_y = generate_minimap(
             x, y, view_width=width, view_height=height,
-            output_path=minimap_path, return_coords=True
+            output_path=minimap_path, return_coords=True,
+            zoom=1.3
         )
         marker_x_pct = marker_x / width * 100
         marker_y_pct = marker_y / height * 100

--- a/Game_Modules/MiniMap.py
+++ b/Game_Modules/MiniMap.py
@@ -11,7 +11,7 @@ MINIMAP_PATH = os.path.join(os.path.dirname(__file__), '../Textures/mini-map.png
 
 def generate_minimap(player_x, player_y, view_width=1500, view_height=1000,
                      marker_radius=5, output_path=None, return_coords=False,
-                     full_map=False):
+                     full_map=False, zoom=1.0):
     """
     Crops the mini-map so the player is centered when possible, overlays a marker
     at the player's location within the cropped view, and saves/returns the image.
@@ -23,6 +23,9 @@ def generate_minimap(player_x, player_y, view_width=1500, view_height=1000,
     Returns:
         Cropped PIL Image object. If ``return_coords`` is True, also returns the
         player's coordinates within the cropped image as ``(x, y)``.
+        ``zoom`` controls how much surrounding area to include. Values > 1.0
+        show more of the map (zooming out) while keeping the final image size
+        constant.
     """
     # Load the mini-map image
     minimap = Image.open(MINIMAP_PATH).convert('RGBA')
@@ -45,24 +48,32 @@ def generate_minimap(player_x, player_y, view_width=1500, view_height=1000,
             return resized, player_x * scale_x, player_y * scale_y
         return resized
 
-    # Calculate crop box so player is centered
-    left = int(player_x - view_width // 2)
-    upper = int(player_y - view_height // 2)
-    right = left + view_width
-    lower = upper + view_height
+    # Calculate crop box so player is centered. ``zoom``>1 expands the
+    # surrounding area while keeping the output size fixed.
+    crop_w = int(view_width * zoom)
+    crop_h = int(view_height * zoom)
+    left = int(player_x - crop_w // 2)
+    upper = int(player_y - crop_h // 2)
+    right = left + crop_w
+    lower = upper + crop_h
 
     # Clamp crop box to image boundaries
-    left = max(0, min(left, map_w - view_width))
-    upper = max(0, min(upper, map_h - view_height))
-    right = left + view_width
-    lower = upper + view_height
+    left = max(0, min(left, map_w - crop_w))
+    upper = max(0, min(upper, map_h - crop_h))
+    right = left + crop_w
+    lower = upper + crop_h
 
     cropped = minimap.crop((left, upper, right, lower))
+    # Resize back down to the desired view size if zoomed out
+    if zoom != 1.0:
+        cropped = cropped.resize((view_width, view_height), Image.BILINEAR)
 
     # Draw marker at the player's coordinates relative to the crop
     draw = ImageDraw.Draw(cropped)
-    draw_x = player_x - left
-    draw_y = player_y - upper
+    scale_x = view_width / crop_w
+    scale_y = view_height / crop_h
+    draw_x = (player_x - left) * scale_x
+    draw_y = (player_y - upper) * scale_y
     draw.ellipse([
         (draw_x - marker_radius, draw_y - marker_radius),
         (draw_x + marker_radius, draw_y + marker_radius)


### PR DESCRIPTION
## Summary
- allow MiniMap.generate_minimap to take a zoom factor
- enlarge cropped area when generating minimap in `flask_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68831f133ed48320ba15dd12fb40af43