### PR TITLE
Add final boss win condition and victory page

### DIFF
--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -166,7 +166,7 @@
                 <div class="movement-grid">
                   {% for nbr in neighbors %}
                     <button name="command" value="go {{ nbr }}" class="action-btn movement-btn">
-                      <span class="btn-icon">🚶</span>
+                      <span class="btn-icon">{% if nbr in cleared_rooms %}💀{% else %}🚶{% endif %}</span>
                       <span class="btn-text">{{ ROOM_NAMES[nbr] }}</span>
                       <span class="btn-arrow">→</span>
                     </button>

--- a/Flask/Templates/win.html
+++ b/Flask/Templates/win.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block title %}Victory{% endblock %}
+
+{% block content %}
+<div class="container" style="text-align:center;padding:2rem;">
+  <h1>Congratulations traveler, you have beaten the dungeon!</h1>
+  <p>You can Save your game and play more, or try on a harder difficulty.</p>
+  <div class="credits" style="margin:2rem auto;max-width:400px;border:1px solid #ccc;padding:1rem;">
+    <h2>Credits</h2>
+    <ul style="list-style:none;padding:0;">
+      <li>Abdelrahman Abdelsalam</li>
+      <li>Adam Orwig</li>
+      <li>Alex Foster</li>
+      <li>Angela Adofo</li>
+      <li>Ayele Ejgu</li>
+      <li>Brian Parham</li>
+      <li>Christopher Macala</li>
+      <li>Claire Lindstrom</li>
+      <li>Craig McLeish</li>
+    </ul>
+  </div>
+  <a href="{{ url_for('save_as') }}" class="button">Save Game</a>
+  <a href="{{ url_for('menu') }}" class="button">Main Menu</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Track cleared rooms in session and show skull icon on paths that have been cleared
- Spawn "Undead Necro Warlord" boss after clearing all rooms and redirect to a new victory page on defeat
- Add unit test ensuring boss spawn after clearing final room

## Testing
- `pytest tests/test_flask_app.py::test_spawn_final_boss_after_all_rooms_cleared -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902ae9e2e88320970ad2a2526d1057