### PR TITLE
Persist settings and scale health display

### DIFF
--- a/Flask/Templates/base.html
+++ b/Flask/Templates/base.html
@@ -186,6 +186,20 @@
 
       window.endLoading = () => { overlay.style.display = 'none'; };
 
+      window.resizeHealthText = () => {
+        document.querySelectorAll('.health-text').forEach(el => {
+          el.style.fontSize = '';
+          el.style.width = 'auto';
+          const parentWidth = el.parentElement.clientWidth;
+          let size = parseFloat(getComputedStyle(el).fontSize);
+          while (el.offsetWidth > parentWidth && size > 8) {
+            size -= 1;
+            el.style.fontSize = size + 'px';
+          }
+          el.style.width = '100%';
+        });
+      };
+
       window.initUI = () => {
         document.querySelectorAll('form').forEach(form => {
           if (form.getAttribute('action') !== saveAsURL) {
@@ -290,9 +304,13 @@
           });
         });
         observer.observe(overlay, { attributes: true });
+
+        resizeHealthText();
       };
 
       initUI();
+      window.addEventListener('resize', resizeHealthText);
+      resizeHealthText();
       console.log('🏰 Dungeon Crawler Enhanced UI Loaded Successfully! 🗡️');
     });
 

--- a/Flask/Templates/explore.html
+++ b/Flask/Templates/explore.html
@@ -63,7 +63,7 @@
           <div class="stat-icon">❤️</div>
           <div class="stat-content">
             <div class="stat-label">Health</div>
-            <div class="stat-value">{{ player.hp }} / {{ player.max_hp }}</div>
+            <div class="stat-value health-text">{{ player.hp }} / {{ player.max_hp }}</div>
           </div>
           <div class="stat-bar">
             <div class="stat-fill health-fill" style="width: {{ (player.hp / player.max_hp * 100)|round }}%"></div>

--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -7,7 +7,9 @@ import os, sys, io, time, zipfile, json, random, math
 # ensure Game_Modules package is importable
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from Game_Modules.import_assets import inventory, gear, game_map, enemies, player_template
+from Game_Modules.import_assets import (
+    inventory, gear, game_map, enemies, player_template, settings as default_settings
+)
 from Game_Modules import llm_client
 from Game_Modules.save_load   import save_game
 from Game_Modules import save_load
@@ -59,6 +61,8 @@ VOICE_CHOICES = available_voices()
 # ----- MAIN MENU -----
 @app.route('/')
 def menu():
+    if 'settings' not in session:
+        session['settings'] = default_settings.copy()
     current = session.get('settings', {}).get('difficulty', 'Normal')
     if not app.config.get('TESTING'):
         start_room = player_template.get('start_room', 'R1_1')
@@ -206,6 +210,7 @@ def save_as():
             z.writestr('inventory.json', json.dumps(player_inv,   indent=2))
             raw_map = list(game_map.values()) if isinstance(game_map, dict) else game_map
             z.writestr('map.json',       json.dumps(raw_map,     indent=2))
+            z.writestr('settings.json',  json.dumps(session.get('settings', {}), indent=2))
             if os.path.isdir(temp_utils.VOICE_DIR):
                 for fname in os.listdir(temp_utils.VOICE_DIR):
                     fp = os.path.join(temp_utils.VOICE_DIR, fname)

--- a/Flask/static/style.css
+++ b/Flask/static/style.css
@@ -544,6 +544,7 @@ table.inventory tr:hover td {
 
 /* Health bar animation */
 .health-bar {
+  position: relative;
   width: 100%;
   height: 10px;
   background: var(--panel-dark);
@@ -558,6 +559,21 @@ table.inventory tr:hover td {
   background: linear-gradient(90deg, var(--health-color), #ff6b6b);
   transition: width 0.5s ease;
   box-shadow: 0 0 10px rgba(231, 76, 60, 0.5);
+}
+
+.health-text {
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.health-bar .health-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
 }
 
 /* Page transition effects */

--- a/Game_Modules/Game_Assets/settings.json
+++ b/Game_Modules/Game_Assets/settings.json
@@ -1,0 +1,11 @@
+{
+  "difficulty": "Normal",
+  "music": true,
+  "llm_return_length": 50,
+  "voice": true,
+  "voice_name": "default",
+  "map_size": "Medium",
+  "hide_minimap": false,
+  "display_theme": "Standard",
+  "llm_device": "cpu"
+}

--- a/Game_Modules/export_assets.py
+++ b/Game_Modules/export_assets.py
@@ -26,6 +26,7 @@ def export_assets():
         'gear': import_assets.gear,
         'map': import_assets.game_map,
         'enemies': import_assets.enemies,
+        'settings': import_assets.settings,
     }
 
     # Write out the combined save file

--- a/Game_Modules/import_assets.py
+++ b/Game_Modules/import_assets.py
@@ -29,6 +29,7 @@ _raw_gear            = load_json_file('gear.json')
 _raw_game_map        = load_json_file('map.json')
 _raw_enemies         = load_json_file('enemies.json')
 _raw_player_template = load_json_file('player-template.json')
+_raw_settings        = load_json_file('settings.json')
 
 # Process assets
 inventory       = _raw_inventory
@@ -43,11 +44,13 @@ except (TypeError, KeyError):
 
 enemies         = _raw_enemies
 player_template = _raw_player_template
+settings        = _raw_settings
 
 __all__ = [
     'inventory',
     'gear',
     'game_map',
     'enemies',
-    'player_template'
+    'player_template',
+    'settings'
 ]

--- a/Game_Modules/save_load.py
+++ b/Game_Modules/save_load.py
@@ -73,12 +73,17 @@ def load_game_from_zip(stream, session):
 def import_game_data(z, session):
     # 2) player.json → session
     player_data = json.loads(z.read('player.json').decode('utf-8'))
+    import_assets.player_template = player_data
+    stats = player_data.get('stats', {})
     session['player_name']      = player_data.get('name', '')
     session['room_id']          = player_data.get('current_map_location', '')
     session['level']            = player_data.get('level', 1)
     session['xp']               = player_data.get('xp', 0)
-    session['hp']               = player_data.get('hp', player_data.get('stats',{}).get('current_health',10))
+    session['hp']               = player_data.get('hp', stats.get('current_health',10))
     session['equipped']         = player_data.get('equipped', {})
+    session['attack']           = stats.get('attack', 0)
+    session['defense']          = stats.get('defense', 0)
+    session['speed']            = stats.get('speed', 0)
 
     # 3) inventory.json → session
     session['inventory']        = json.loads(z.read('inventory.json').decode('utf-8'))
@@ -93,6 +98,14 @@ def import_game_data(z, session):
 
     # 6) enemies.json → import_assets.enemies
     import_assets.enemies = json.loads(z.read('enemies.json').decode('utf-8'))
+
+    # 7) settings.json → session and import_assets
+    try:
+        settings_data = json.loads(z.read('settings.json').decode('utf-8'))
+    except KeyError:
+        settings_data = {}
+    session['settings'] = settings_data
+    import_assets.settings = settings_data
 
     for info in z.infolist():
         if info.filename.startswith('voice/'):

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -21,14 +21,31 @@ def test_load_game_from_zip(tmp_path):
     session = DummySession()
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, 'w') as z:
-        z.writestr('player.json', json.dumps({'name':'h','current_map_location':'A','level':1,'xp':0,'stats':{'current_health':5}}))
+        z.writestr('player.json', json.dumps({
+            'name': 'h',
+            'current_map_location': 'A',
+            'level': 1,
+            'xp': 0,
+            'stats': {
+                'current_health': 5,
+                'attack': 7,
+                'defense': 3,
+                'speed': 2
+            }
+        }))
         z.writestr('inventory.json', json.dumps([]))
-        z.writestr('map.json', json.dumps([{'room_id':'A'}]))
+        z.writestr('map.json', json.dumps([{'room_id': 'A'}]))
         z.writestr('gear.json', json.dumps({}))
         z.writestr('enemies.json', json.dumps([]))
+        z.writestr('settings.json', json.dumps({'difficulty': 'Normal'}))
     buf.seek(0)
     save_load.load_game_from_zip(buf, session)
     assert session['player_name'] == 'h'
     assert session['room_id'] == 'A'
     assert session['level'] == 1
     assert isinstance(session['inventory'], list)
+    assert session['settings']['difficulty'] == 'Normal'
+    from Game_Modules import import_assets
+    assert import_assets.player_template['stats']['attack'] == 7
+    assert import_assets.player_template['stats']['defense'] == 3
+    assert import_assets.player_template['stats']['speed'] == 2


### PR DESCRIPTION
## Summary
- Load and export settings through a new `settings.json` asset
- Restore attack/defense/speed when importing saves
- Scale health text to avoid overflow and added dynamic resizing script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903733b204832085fd151c32ebdb30