### PR TITLE
Fix enemy HP loading from JSON

### DIFF
--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -626,7 +626,13 @@ def artifact():
             b = boss.copy()
             lvl = b.get('level', 1)
             b['level'] = lvl
-            hp = b.get('stats', {}).get('health', 15 + (lvl - 1) * 5)
+            hp = b.get('stats', {}).get('health')
+            if hp is None:
+                ref = next((en for en in enemies if en.get('name') == b.get('name')), None)
+                if ref:
+                    hp = ref.get('stats', {}).get('health')
+            if hp is None:
+                hp = 15 + (lvl - 1) * 5
             b['max_hp'] = hp
             b['current_hp'] = hp
             session['encounter'] = b

--- a/Game_Modules/game_utils.py
+++ b/Game_Modules/game_utils.py
@@ -171,7 +171,15 @@ def move_player(session, tgt_room, spawn_chance=0.6):
 # TODO Rename this here and in `move_player`
 def enemy_audio_desc(e, session):
     lvl = e.get('level', 1)
-    base_hp = e.get('stats', {}).get('health', 15 + (lvl - 1) * 5)
+
+    stats = e.get('stats')
+    if not stats or 'health' not in stats:
+        match = next((en for en in RAW_ENEMIES if en.get('name') == e.get('name')), None)
+        if match:
+            stats = match.get('stats', {}).copy()
+            e['stats'] = stats
+
+    base_hp = stats.get('health') if stats and 'health' in stats else 15 + (lvl - 1) * 5
     e['level'] = lvl
     e['max_hp'] = base_hp
     e['current_hp'] = base_hp


### PR DESCRIPTION
## Summary
- ensure encountered enemies pull health from `enemies.json`
- do the same for boss spawning logic

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890468102588320968eb1573eefe38d