### PR TITLE
Fix potion dropdown functionality

### DIFF
--- a/Flask/Templates/base.html
+++ b/Flask/Templates/base.html
@@ -227,13 +227,22 @@
           });
         });
 
-        document.querySelectorAll('button, .button').forEach(btn => {
-          btn.addEventListener('mouseenter', () => { btn.style.transform = 'translateY(-3px) scale(1.02)'; });
-          btn.addEventListener('mouseleave', () => { btn.style.transform = 'translateY(0) scale(1)'; });
-        });
+          document.querySelectorAll('button, .button').forEach(btn => {
+            btn.addEventListener('mouseenter', () => { btn.style.transform = 'translateY(-3px) scale(1.02)'; });
+            btn.addEventListener('mouseleave', () => { btn.style.transform = 'translateY(0) scale(1)'; });
+          });
 
-        function createParticle(x, y, color = '#e67e22') {
-          const particle = document.createElement('div');
+          const potionToggle = document.getElementById('potion-toggle');
+          const potionPanel = document.getElementById('potion-panel');
+          if (potionToggle && potionPanel) {
+            potionToggle.addEventListener('click', () => {
+              potionToggle.style.display = 'none';
+              potionPanel.style.display = 'block';
+            });
+          }
+
+          function createParticle(x, y, color = '#e67e22') {
+            const particle = document.createElement('div');
           particle.style.cssText = `position:fixed;width:4px;height:4px;background:${color};border-radius:50%;pointer-events:none;z-index:9998;left:${x}px;top:${y}px;box-shadow:0 0 6px ${color};`;
           document.body.appendChild(particle);
           const deltaX = (Math.random() - 0.5) * 100;

--- a/Flask/Templates/fight.html
+++ b/Flask/Templates/fight.html
@@ -247,18 +247,7 @@
   {% endif %}
 </div>
 
-<script>
-  const toggle = document.getElementById('potion-toggle');
-  const panel = document.getElementById('potion-panel');
-  if (toggle && panel) {
-    toggle.addEventListener('click', () => {
-      toggle.style.display = 'none';
-      panel.style.display = 'block';
-    });
-  }
-</script>
-
-<style>
+  <style>
 /* Enhanced battle-specific styles */
 .battle-container {
   max-width: 1200px;


### PR DESCRIPTION
## Summary
- Add potion button handler to global init code so SPA navigation reattaches toggle events
- Remove inline potion script and keep dropdown markup in fight template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689049afd2c88320954801a93f475aba