### PR TITLE
Fix equipment loading error for save files

### DIFF
--- a/Flask/flask_app.py
+++ b/Flask/flask_app.py
@@ -340,9 +340,9 @@ def explore():
     base   = player_template['stats']
     eq     = session.get('equipped', {})
     bonus  = {
-        'attack':  sum(i.get('attack',0)  for i in eq.values() if i),
-        'defense': sum(i.get('defense',0) for i in eq.values() if i),
-        'speed':   sum(i.get('speed',0)   for i in eq.values() if i),
+        'attack':  sum(i.get('attack',0)  for i in eq.values() if isinstance(i, dict)),
+        'defense': sum(i.get('defense',0) for i in eq.values() if isinstance(i, dict)),
+        'speed':   sum(i.get('speed',0)   for i in eq.values() if isinstance(i, dict)),
     }
     from Game_Modules.entities import Player
     max_hp = player_template.get('stats', {}).get('max_health', 100)

--- a/Game_Modules/save_load.py
+++ b/Game_Modules/save_load.py
@@ -81,7 +81,7 @@ def import_game_data(z, session):
     session['level']            = player_data.get('level', 1)
     session['xp']               = player_data.get('xp', 0)
     session['hp']               = player_data.get('hp', stats.get('current_health',10))
-    session['equipped']         = player_data.get('equipped') or player_data.get('Equipped', {})
+    eq_raw                      = player_data.get('equipped') or player_data.get('Equipped', {})
     session['attack']           = stats.get('attack', 0)
     session['defense']          = stats.get('defense', 0)
     session['speed']            = stats.get('speed', 0)
@@ -101,6 +101,15 @@ def import_game_data(z, session):
     gear_data = json.loads(z.read('gear.json').decode('utf-8'))
     import_assets.gear.clear()
     import_assets.gear.update(gear_data)
+
+    # convert equipped item names into gear dictionaries if needed
+    equipped = {}
+    for slot, item in eq_raw.items():
+        if isinstance(item, dict):
+            equipped[slot] = item
+        else:
+            equipped[slot] = import_assets.gear.get(item)
+    session['equipped'] = equipped
 
     # 6) enemies.json → import_assets.enemies
     enemies_data = json.loads(z.read('enemies.json').decode('utf-8'))

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -49,3 +49,31 @@ def test_load_game_from_zip(tmp_path):
     assert import_assets.player_template['stats']['attack'] == 7
     assert import_assets.player_template['stats']['defense'] == 3
     assert import_assets.player_template['stats']['speed'] == 2
+
+
+def test_load_game_from_zip_equipped_names(tmp_path):
+    session = DummySession()
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as z:
+        z.writestr('player.json', json.dumps({
+            'name': 'h',
+            'current_map_location': 'A',
+            'level': 1,
+            'xp': 0,
+            'stats': {
+                'current_health': 5,
+                'attack': 7,
+                'defense': 3,
+                'speed': 2
+            },
+            'Equipped': {'weapon': 'Sword'}
+        }))
+        z.writestr('inventory.json', json.dumps([]))
+        z.writestr('map.json', json.dumps([{'room_id': 'A'}]))
+        z.writestr('gear.json', json.dumps({'Sword': {'name': 'Sword', 'type': 'weapon', 'attack': 5}}))
+        z.writestr('enemies.json', json.dumps([]))
+        z.writestr('settings.json', json.dumps({}))
+    buf.seek(0)
+    save_load.load_game_from_zip(buf, session)
+    assert session['equipped']['weapon']['name'] == 'Sword'
+    assert session['equipped']['weapon']['attack'] == 5


### PR DESCRIPTION
## Summary
- Resolve equipment names to gear data when loading a save archive
- Guard player stat bonuses against non-dict equipment
- Add regression test ensuring saves with string item names load correctly

## Testing
- `pytest tests/test_save_load.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68904b3a447c8320ba1537ba354f96e8